### PR TITLE
Fixed NPE when accessor method not found for a property

### DIFF
--- a/prospecto-runtime/src/main/java/org/soulwing/prospecto/runtime/accessor/ReflectionAccessorFactory.java
+++ b/prospecto-runtime/src/main/java/org/soulwing/prospecto/runtime/accessor/ReflectionAccessorFactory.java
@@ -21,6 +21,7 @@ package org.soulwing.prospecto.runtime.accessor;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
 
 import org.soulwing.prospecto.api.AccessType;
 
@@ -55,8 +56,19 @@ public class ReflectionAccessorFactory implements AccessorFactory {
     for (final PropertyDescriptor descriptor :
         Introspector.getBeanInfo(declaringClass).getPropertyDescriptors()) {
       if (descriptor.getName().equals(name)) {
-        return new PropertyAccessor(descriptor.getReadMethod(),
-            descriptor.getWriteMethod());
+        Method readMethod = descriptor.getReadMethod();
+        if (readMethod == null) {
+          throw new NoSuchMethodException(declaringClass.getName() +
+              " does not have a read method for property '" + name + "'");
+        }
+
+        Method writeMethod = descriptor.getWriteMethod();
+        if (writeMethod == null) {
+          throw new NoSuchMethodException(declaringClass.getName() +
+              " does not have a write method for property '" + name + "'");
+        }
+
+        return new PropertyAccessor(readMethod, writeMethod);
       }
     }
     throw new NoSuchMethodException(declaringClass.getName()

--- a/prospecto-runtime/src/test/java/org/soulwing/prospecto/runtime/accessor/ReflectionAccessorFactoryTest.java
+++ b/prospecto-runtime/src/test/java/org/soulwing/prospecto/runtime/accessor/ReflectionAccessorFactoryTest.java
@@ -110,6 +110,8 @@ public class ReflectionAccessorFactoryTest {
       return PUBLIC_METHOD_VALUE;
     }
 
+    public void setPublicMethod(Object value) { }
+
   }
 
 }


### PR DESCRIPTION
Example case:

``` java
class PurchaseOrder {
  private BigDecimal total;
  public BigDecimal total() {
    return total;
  }
}
```

Yes... it's a problem in which the code is breaking the conventions for accessors.  But, this fix at least helps debug the issue.

This is asserting that a getter and a setter are found since the ```PropertyAccessor``` is assuming it gets valid getter and setter methods.  May need to think about use cases in which one or the other isn't actually needed - do we _always_ need both a getter and a setter?

So... may be another approach to fix it too.  Thoughts?