### PR TITLE
Fix conditional that's always true

### DIFF
--- a/prospecto-runtime/src/main/java/org/soulwing/prospecto/runtime/discriminator/ConcreteDiscriminatorEventService.java
+++ b/prospecto-runtime/src/main/java/org/soulwing/prospecto/runtime/discriminator/ConcreteDiscriminatorEventService.java
@@ -94,7 +94,7 @@ public class ConcreteDiscriminatorEventService
     final View.Event.Type complementType = event.getType().complement();
     while (events.hasNext() && event.getType() != complementType) {
       event = events.next();
-      if (event.getType() != event.getType().complement()) {
+      if (event.getType() != complementType) {
         skipEvent(event, events);
       }
     }


### PR DESCRIPTION
For incredibly large payloads (an array of 10k items), we were running into `StackOverflowError`s when trying to convert the `View` to an `Entity`. Digging in, I saw this conditional, which I imagine could never be false. The event's type is always not equal to its complement. 

I made the change in this PR and tested and the errors were resolved and some high-level tests on our app still seemed to work. However, I'm not sure what other side effects may occur as this part of the code doesn't have unit tests and I'm not 100% sure what all of the conditions at play are. So, feel free to tweak/change as needed!